### PR TITLE
Add README link test

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 
 <a align="right" href="https://open.spotify.com/playlist/3FrFoFhpGojEKvWXc4DvNu?si=m0sHDO7bRb2ZbjT-yIjslA"><img src="https://raw.githubusercontent.com/vultuk/vultuk/main/img/code-playlist.png" alt="Vultuk's Github Stats"  align="right" height="242"></a>
 
-<img src="https://github-readme-stats.vercel.app/api/wakatime?username=@vultuk&count_private=true&show_icons=true&theme=vue&include_all_commits=true" alt="Vultuk's Github Stats">
+<img src="https://github-readme-stats.vercel.app/api/wakatime?username=vultuk&count_private=true&show_icons=true&theme=vue&include_all_commits=true" alt="Vultuk's Github Stats">
 
 - See even more time stuffs here :point_right: <a href="https://wakatime.com/@vultuk">Wakatime</a>
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -q

--- a/tests/test_readme_links.py
+++ b/tests/test_readme_links.py
@@ -1,0 +1,10 @@
+import re
+from pathlib import Path
+
+def test_wakatime_link():
+    readme_path = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme_path.read_text()
+    match = re.search(r'<img src="([^"]*github-readme-stats\.vercel\.app/api/wakatime[^\"]*)"', content)
+    assert match, "Wakatime image link not found"
+    link = match.group(1)
+    assert link.startswith("https://github-readme-stats.vercel.app/api/wakatime?username=vultuk"), link


### PR DESCRIPTION
## Summary
- update README with correct Wakatime link
- add pytest config
- add test to verify README's Wakatime link

## Testing
- `python3 -m py_compile tests/test_readme_links.py`
- `pytest -q` *(fails: command not found)*